### PR TITLE
dx: Claude Code action with Nix CI environment

### DIFF
--- a/.github/actions/nix-ci/action.yml
+++ b/.github/actions/nix-ci/action.yml
@@ -1,0 +1,19 @@
+name: Setup Nix CI
+description: Install Nix with caching and activate the CI dev shell
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Setup Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
+
+    - name: Activate CI dev shell
+      shell: bash
+      run: |
+        # Build the CI shell and add its tools to PATH for subsequent steps
+        nix develop .#ci --command bash -c 'echo "$PATH"' \
+          | tr ':' '\n' \
+          | grep '/nix/store' >> "$GITHUB_PATH"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,32 +19,34 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Setup Nix CI
+        uses: ./.github/actions/nix-ci
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          allowed_tools: |
+            Read,Grep,Glob,Task,Edit,Write
+            Bash(git diff:*)
+            Bash(git log:*)
+            Bash(git add:*)
+            Bash(git commit:*)
+            Bash(git push:*)
+            Bash(gh pr comment:*)
+            Bash(gh pr view:*)
+            Bash(gh issue create:*)
+            Bash(make *)
+            Bash(swiftlint *)


### PR DESCRIPTION
Adds `@claude` support in GitHub issues and PRs, backed by the project's Nix flake.

## How it works

The flake now builds on `x86_64-linux` with a lightweight `devShells.ci` (swiftlint + pre-commit hook). A reusable composite action at [`.github/actions/nix-ci`]($BASE_URL/.github/actions/nix-ci/action.yml) handles Nix install + binary caching + shell activation, so any future workflow gets the same environment in one line:

```yaml
- uses: ./.github/actions/nix-ci
```

The Claude Code workflow uses this action, then runs with write permissions and `allowed_tools` scoped to git, gh, make, and swiftlint. Claude's commits go through the same pre-commit hook (swiftlint `--strict`) that runs locally.

## Caveat

SwiftLint may not build on `x86_64-linux` in current nixpkgs-unstable. First CI run will confirm.