### PR TITLE
dx: issue-to-prompt linkage in frontmatter

### DIFF
--- a/.claude/agents/workflow-reviewer.md
+++ b/.claude/agents/workflow-reviewer.md
@@ -21,6 +21,7 @@ goal: "<one sentence>"
 author: "<github-username>"
 project: "Slate"
 tags: [<tag>, ...]
+issue: ""                        # optional — GitHub issue number or URL
 conversation_id: "<uuid>"        # optional
 commit_hash: "<sha>"             # filled at commit time
 created: "<ISO 8601>"
@@ -78,6 +79,7 @@ git diff $ARGUMENTS...HEAD -- 'workflows/' 'CLAUDE.md'
 4. **Broken prompt↔meta links** — Meta entries listing prompts in `prompts:` that don't exist, or prompts associated with work described in a meta entry but not listed.
 5. **Meta entry gaps** — `previous:` field pointing to a non-existent entry, or numbering gaps in the sequence.
 6. **CLAUDE.md staleness** — If the PR changes project structure, conventions, or learnings, check whether CLAUDE.md should be updated to reflect them.
+7. **Missing issue link** — Prompt files whose `goal` references a GitHub issue number (e.g., "#12") but have an empty `issue` field.
 
 ### What to Ignore
 

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -47,6 +47,8 @@ Read in parallel:
 
 Build a mental model: what was the developer trying to do, what decisions did they make, and what should a reviewer understand?
 
+6. **Linked issues**: Check prompt files for a non-empty `issue` field. Collect these — they'll be used to auto-close issues in the PR description.
+
 ## Step 3: Determine PR structure
 
 Infer the PR type from the changes:
@@ -85,6 +87,7 @@ If any of these are present, the PR description **must** include a **"Setup / en
 ```markdown
 ## <Opening context>
 1-3 sentences: what this PR is and why it matters. Not a commit message — frame it for the reviewer.
+If prompt files have linked issues, add `Closes #<number>` (one per line) so GitHub auto-closes them on merge.
 
 ---
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -59,6 +59,7 @@ goal: "<one sentence>"
 author: "<user>"
 project: "<project name>"
 tags: [<framework>, <domain>, <theme>]
+issue: ""                                    # optional — GitHub issue number (e.g. 12) or URL
 conversation_id: "<claude code conversation id if available>"
 commit_hash: "<filled at commit time>"
 created: "<ISO 8601 timestamp>"
@@ -90,7 +91,7 @@ created: "<ISO 8601 timestamp>"
 ### Prompt File Indexing
 
 Frontmatter fields are the index. Searchable by:
-- `author`, `project`, `tags`, `conversation_id`, `commit_hash`, `status`
+- `author`, `project`, `tags`, `issue`, `conversation_id`, `commit_hash`, `status`
 
 Use `Grep` across `workflows/prompts/` frontmatter to query the library.
 


### PR DESCRIPTION
## Summary

Adds an optional `issue` field to prompt frontmatter, closing the traceability loop: **Issue → Prompt → Commits → PR → Review**.

- **`/prompt` skill** — template now includes `issue: ""` in frontmatter; field added to searchable index
- **workflow-reviewer** — documents the field and flags prompts whose `goal` references an issue number but leave `issue` empty
- **draft-pr** — collects linked issues from prompts and emits `Closes #N` in PR descriptions for auto-close on merge

No changes to existing prompt files, CI workflows, or meta entries.