### PR TITLE
docs: journal entries 003-005 + meta-workflow refinements

### DIFF
--- a/.claude/agents/session-miner.md
+++ b/.claude/agents/session-miner.md
@@ -1,0 +1,66 @@
+---
+name: session-miner
+description: Lightweight transcript miner that reads a single session JSONL and returns a compact structured summary
+tools: Read, Grep
+model: haiku
+---
+
+# Session Miner
+
+You are a fast, focused transcript miner. You receive a session JSONL file path and optional git context via `$ARGUMENTS`, and return a compact structured summary. **Nothing else.**
+
+## Input
+
+`$ARGUMENTS` contains:
+- **Line 1**: Absolute path to a single `.jsonl` transcript file
+- **Line 2** (optional): `workdir: /path/to/project` — the project working directory
+- **Line 3+** (optional): `commits:` followed by git log lines relevant to this session's time window
+
+Example:
+```
+/Users/claude/.claude/projects/-Users-claude-Slate/abc12345-session.jsonl
+workdir: /Users/claude/Slate
+commits:
+a1b2c3d feat: add theme design system
+e4f5g6h fix: dark mode safe area edges
+```
+
+If commits are provided, correlate them with the session activity to identify which commits resulted from this session.
+
+## How to Read the Transcript
+
+Each line in the file is a JSON object. The useful lines have `"role":"user"` or `"role":"assistant"` with a `"content"` field containing the actual conversation.
+
+**Context-safe reading strategy:**
+
+1. **Check file size first** — use Grep with `output_mode: "count"` and pattern `"role"` to estimate line count.
+2. **If ≤ 300 lines** — read the whole file.
+3. **If > 300 lines** — read in 3 chunks using `offset`/`limit`:
+   - First 100 lines (session start — captures the goal)
+   - Middle 100 lines (use `offset` at ~40% of total lines — captures decisions)
+   - Last 100 lines (session end — captures outcome and problems)
+4. **Skip noise** — ignore lines containing `"type":"tool_use"`, `"type":"tool_result"`, or `"role":"system"`. Focus only on human and assistant text content.
+
+## Output Format
+
+Return **exactly** this format — no preamble, no markdown fences, no commentary:
+
+```
+SESSION: <filename without path, e.g. abc12345-...jsonl>
+GOAL: <1 sentence — what the developer was trying to accomplish>
+OUTCOME: <1 sentence — what actually got done>
+DECISIONS: <bullet list, max 4 — key choices made and brief rationale>
+PROBLEMS: <bullet list, max 3 — what went wrong and resolution>
+FILES: <comma-separated list of key files touched, max 8>
+COMMITS: <list of commit hashes + messages from this session, or "none identified">
+THINKING: <1-2 sentences — what the developer deliberated on>
+```
+
+## Rules
+
+- **Hard limit: 250 words total.** Be terse.
+- **Omit empty sections.** If no problems occurred, skip PROBLEMS entirely. If no commits provided or none match, skip COMMITS.
+- **Never return raw transcript content.** Summarize only.
+- **Do not read any files other than the one in $ARGUMENTS.**
+- **Do not write or edit any files.**
+- **Commit correlation**: If commit lines are provided, match them to session activity by looking for file names, feature descriptions, or commit messages mentioned in the transcript. Only list commits that clearly belong to this session.

--- a/.claude/skills/meta-workflow/SKILL.md
+++ b/.claude/skills/meta-workflow/SKILL.md
@@ -25,7 +25,7 @@ For first-time authors, copy `workflows/meta/000-template.md` as starting point.
 
 ## Step 2: Determine Scope
 
-Ask the user (via `AskUserQuestion`) what this entry covers:
+If the user provided explicit scope (e.g., "cover all sessions since last entry", "document the PR review work"), use that. Otherwise, ask (via `AskUserQuestion`) what this entry covers:
 - Feature or set of features just completed
 - Research / exploration session
 - Onboarding (first entry)
@@ -35,44 +35,100 @@ Ask the user (via `AskUserQuestion`) what this entry covers:
 
 Session transcripts live in `~/.claude/projects/`. The current project directory is named with the workspace absolute path's separators replaced by dashes (e.g., `/Users/me/Slate` → `-Users-me-Slate`).
 
+### Context budget
+
+Session mining is the most expensive step. **The main agent never reads raw transcripts.** All reading is delegated to `session-miner` agents (`.claude/agents/session-miner.md`) which run on `haiku`, read independently, and return only a compact ~200 word summary each.
+
 ### Discovery process
 
-First, derive the project directory name:
-```bash
-PROJECT_DIR=$(pwd | sed 's|/|-|g')
+#### 1. Build the covered-sessions set
+
+Read the `sessions:` frontmatter from **every** existing entry in `workflows/meta/<author>/`. Collect each `id:` value into a set of 8-character prefixes. These sessions are already documented and must be excluded.
+
+#### 2. Find uncovered sessions via Python
+
+**Always use Python for session discovery.** Shell-based `stat`/`date` commands are unreliable — the Nix devShell provides GNU coreutils, so macOS-style flags (`stat -f`, `date -j`) silently fail.
+
+Run this Python script (adjust `covered` set from step 1):
+
+```python
+import os, glob, json
+from datetime import datetime, timezone
+
+session_dir = os.path.expanduser("~/.claude/projects/-Users-claude-Slate")
+covered = {"abcd1234", "efgh5678"}  # ← paste actual covered prefixes here
+
+sessions = []
+for f in sorted(glob.glob(os.path.join(session_dir, "*.jsonl"))):
+    basename = os.path.basename(f).replace(".jsonl", "")
+    prefix = basename[:8]
+    if prefix in covered:
+        continue
+    size = os.path.getsize(f)
+    if size < 5000:  # skip trivial sessions (<5KB)
+        continue
+    mod = os.path.getmtime(f)
+    ts = datetime.fromtimestamp(mod, tz=timezone.utc).isoformat()
+    sessions.append((mod, prefix, size, ts, f))
+
+sessions.sort(key=lambda x: x[0])
+for i, (mod, prefix, size, ts, path) in enumerate(sessions, 1):
+    print(f"{i:2d}. {prefix} ({size//1024}KB) {ts} {path}")
+print(f"\nTotal: {len(sessions)} uncovered substantive sessions")
 ```
 
-1. **Find sessions for this project:**
-   ```bash
-   ls ~/.claude/projects/${PROJECT_DIR}/*.jsonl
-   ```
+#### 3. Batch and dispatch
 
-2. **Search for relevant sessions** using keywords from the current work:
-   ```
-   Grep pattern="keyword1|keyword2" path="~/.claude/projects/${PROJECT_DIR}/" glob="*.jsonl"
-   ```
-   Note: Use unquoted keywords (not JSON-escaped). The JSONL content is raw text.
+**Group sessions by theme, not rigid count.** Scan session slugs and timestamps to identify natural thematic clusters (e.g., "all CI/CD work", "meta-workflow tooling", "feature X"). Each cluster becomes one entry regardless of whether it has 3 or 13 sessions.
 
-3. **Get message counts** per file to gauge session size:
-   ```
-   Grep pattern='"type":"user"' path="<dir>" glob="*.jsonl" output_mode="count"
-   ```
+**Practical limits:** Keep each entry under ~15 sessions. If a thematic cluster is larger, split it at a natural boundary (design vs. implementation, or before/after a major decision).
 
-4. **Launch parallel subagents** (one per session, `sonnet` model) to extract:
-   - Main topic/goal
-   - Decisions made and rationale
-   - Problems encountered and solutions
-   - Files created/modified
-   - Key timestamps and duration
-   - Developer thinking — what they went back and forth on
+If uncovered sessions span multiple themes:
+- Write one entry per theme in this invocation (if context allows)
+- Or process the most cohesive cluster first and report a **continuation prompt** for remaining themes:
 
-   Also check `<session-id>/subagents/` directories for subagent transcripts.
+```
+/meta-workflow continue. Entry <NNN> covers <theme> through <last-prefix> (<timestamp>).
+Remaining uncovered sessions (<M> total):
+ 1. <prefix> (<size>KB) <slug> ...
+Group by theme and write the next entry.
+```
 
-5. **Establish chronological order** from timestamps across all sessions.
+#### Git log pre-fetch
 
-### Subagent prompt template
+Before dispatching miners, run **one** `git log` command covering the full time range of the batch:
 
-> Read the conversation transcript at `<path>`. Extract: (1) main goal, (2) decisions made, (3) what was built/changed, (4) problems and solutions, (5) developer thinking. Focus on human messages and assistant text — skip tool call JSON. Keep under 600 words.
+```bash
+git log --oneline --all --date-order --after="<earliest-session-timestamp>" --before="<now>"
+```
+
+This is the only git command the main agent runs. Split the output by timestamp ranges so each miner receives only the commits from its session's time window.
+
+#### Dispatch miners
+
+For each session in the batch, launch a `session-miner` agent:
+- `subagent_type: "session-miner"`
+- `run_in_background: true`
+- `prompt:` formatted as:
+
+```
+/path/to/session.jsonl
+workdir: /Users/claude/Slate
+commits:
+<git log lines from this session's time window>
+```
+
+Each miner correlates the commits with transcript content and reports which commits belong to that session in its COMMITS output field.
+
+Launch **all** miners in a single message so they run concurrently.
+
+#### 4. Collect results
+
+After all background agents finish, read each agent's output. Each returns a structured summary (~200 words) including relevant git commits. Combine them chronologically.
+
+**The main agent does NOT read raw transcripts or analyze git history.** The single `git log` pre-fetch is a mechanical step — all interpretation and correlation is delegated to miners.
+
+#### 5. Proceed to Step 4 using only the collected summaries as source material.
 
 ## Step 4: Write the Entry
 
@@ -108,25 +164,36 @@ updated: "<ISO 8601>"
 <1-3 sentences: what was happening, why this work started>
 
 ## Timeline
-### Phase N: <name> (`<session-id>`, ~duration)
-**What**: <one sentence>
-**Decisions**: ...
-**Problems**: ...
+### <Descriptive name> (`<session-id>` or `<id1>`, `<id2>` if multiple sessions)
+<What was done, decisions made, problems hit — in flowing prose, not rigid sub-headers>
 
 ## Architecture Snapshot  (only if architecture changed)
 
-## Developer Patterns Observed
-- bullet points: what worked, what didn't
-
-## Artifacts
-- [link](assets/NNN/file.png) to visuals, mockups, screenshots
+## Patterns
+- Unique, non-obvious insights only — not restated observations
+- Focus on "what worked" and "what to avoid"
 
 ## Open Questions
 
 ## What's Next
 ```
 
-## Step 5: Handle Assets
+### Writing guidelines for the body
+
+- **Merge related sessions into one phase.** If 3 sessions all work on testing, that's one "Test Strategy & Implementation" phase with multiple session IDs, not 3 separate phases.
+- **Drop trivial sessions entirely.** If a session has no decisions, no problems, and no meaningful outcome (e.g., "opened Xcode"), omit it from the entry. Don't include it with a disclaimer about being trivial.
+- **Weave cross-references into flow.** Write "The Makefile validation still checked the literal string from the earlier refactor" — not a bolted-on "Connection to Phase 1:" note after each section.
+- **No appendices with raw miner output.** The miner summaries are source material, not part of the entry. Synthesize them into the timeline; don't reproduce them.
+- **Patterns must earn their place.** Each bullet should be a genuinely reusable insight. "Design then implement" is good. "We merged PRs" is not a pattern.
+- **Open Questions should be actionable.** Frame as decisions to make, not vague wonderings. Deduplicate across entries — if a question appeared in a previous entry and is still open, reference it rather than restating.
+
+## Step 5: Cross-Author Context
+
+If other authors have journal entries covering the same time period, read them and add a **"Response to \<Author\>'s Journal Entries"** section after the Timeline. This captures cross-pollination: responding to observations, confirming shared findings, noting disagreements.
+
+Only include this section when there's something substantive to respond to — don't force it.
+
+## Step 6: Handle Assets
 
 Store images, screenshots, mockups in `workflows/meta/<author>/assets/<NNN>/`.
 
@@ -150,12 +217,13 @@ When user provides screenshots or references external files:
 
 ## Style Rules
 
-- **Concise and skimmable** — humans skim, not read linearly
+- **Concise and skimmable** — humans skim, not read linearly. Aim for ~150 lines per entry, not 300.
 - **Show thinking, not just output** — "wanted X, considered Y, chose Z because..."
 - **Problems are valuable** — document what went wrong
 - **No implementation code** — reference files and prompts instead
 - **Bold key terms** for scan-reading
-- **Timestamps matter** — session IDs and durations for traceability
+- **Session IDs for traceability** — include them in phase headings so readers can find the raw transcript
+- **Prefer flowing prose over rigid templates** — "Key decision: ..." mid-paragraph is better than a "**Decisions**:" sub-header for every phase
 
 ## Connecting to Prompts
 

--- a/workflows/meta/gudnuf/003-docs-ci-and-onboarding.md
+++ b/workflows/meta/gudnuf/003-docs-ci-and-onboarding.md
@@ -1,0 +1,181 @@
+---
+id: "003"
+title: "Documentation, CI/CD Foundation & Second Developer"
+status: active
+author: gudnuf
+project: Slate
+tags: [documentation, ci, github-actions, pr-review, skills, onboarding, readme, claude-code-action]
+previous: "002"
+sessions:
+  - id: fcd05f8e
+    slug: open-xcode-and-prompt-skills
+    dir: Slate
+  - id: b173c239
+    slug: theme-design-system
+    dir: Slate
+  - id: a28a9db4
+    slug: meta-workflow-002-writing
+    dir: Slate
+  - id: 2c2fdf34
+    slug: claude-md-philosophy
+    dir: Slate
+  - id: b4dfd7ae
+    slug: readme-slash-commands
+    dir: Slate
+  - id: 7f0e6fa9
+    slug: draft-pr-skill-discovery
+    dir: Slate
+  - id: a9fed7dd
+    slug: readme-audit-and-gaps
+    dir: Slate
+  - id: b6c1c610
+    slug: pr-review-workflow-design
+    dir: Slate
+prompts: []
+created: "2026-02-09T00:00:00Z"
+updated: "2026-02-09T01:00:00Z"
+---
+
+# 003: Documentation, CI/CD Foundation & Second Developer
+
+## Context
+
+Entry [002](002-dx-and-polish.md) established the DX infrastructure (Nix devShell, git hooks, Makefile). This entry covers what happened next: polishing documentation for a second developer (Isaac), creating new skills, auditing the README against actual project conventions, and designing the automated PR review system. Isaac's [onboarding](../IsaacMenge/000-onboarding.md) and [environment setup](../IsaacMenge/001-environment-setup.md) entries happened during this same period — the documentation work here was partly in response to friction he encountered.
+
+## Timeline
+
+### Phase 1: Skill Creation (`fcd05f8e`, ~55 min)
+
+**What**: Created two new skills using `/skill-creator`.
+
+**`/open-xcode`** — Opens the Slate Xcode project. Went through 4 iterations refining the SKILL.md. Simple utility skill but exercised the skill-creator workflow.
+
+**`/prompt`** — The prompt engineering skill that became central to the workflow. Defines the "Do it" gate: Claude never executes without explicit approval. Manages prompt file lifecycle (clean up input -> present -> execute in subagent -> save receipt).
+
+**Pattern**: Both skills created in one session. The `/prompt` skill was the more important one — it formalized the idea that every implementation starts with a human-reviewed prompt, not ad-hoc instructions.
+
+### Phase 2: Theme Design System (`b173c239`, ~45 min)
+
+**What**: Created `Theme.swift` with centralized design tokens and refactored all views to use them.
+
+**Built**:
+- `Theme` enum with static properties: colors (using system colors for automatic dark mode), spacing constants, corner radii, priority color helper
+- Refactored `TodoListView`, `TodoRow`, `EditTodoView`, `TodoWidgetView` to reference `Theme.*` instead of hardcoded values
+- Removed unused `Priority.color` property
+
+**Critical fix**: Dark mode had uncolored safe area edges. Fixed with `.scrollContentBackground(.hidden)` + `.background(Theme.background.ignoresSafeArea())` — two lines to fill the entire screen edge-to-edge.
+
+**Decision**: Used system colors (`Color.accentColor`, `Color(.systemBackground)`) over explicit hex values. Automatic light/dark mode support without manual color sets.
+
+### Phase 3: Meta Documentation (`a28a9db4`, ~1 hr)
+
+**What**: Ran `/meta-workflow` to produce entry 002. Spawned 13 parallel session miners to extract summaries from the full session history. This was the first large-scale use of the session-miner subagent pattern.
+
+**Problems**: Several session files exceeded direct read limits (>900KB). Used subagent parallelization with chunked reads and grep-based extraction as fallbacks. Coordinating 13+ concurrent mining tasks required careful orchestration.
+
+### Phase 4: CLAUDE.md Philosophy & TODOs (`2c2fdf34`, ~5 min)
+
+**What**: Added the "Philosophy" section to the top of CLAUDE.md, defining two key principles:
+1. Skills are written for humans, used by Claude
+2. CLAUDE.md is a living document, primarily for Claude, tracked by humans
+
+Also added a TODO for code signing on real devices — identified that unsigned builds silently skip App Group entitlements, causing `containerURL` to return `nil`. Cross-referenced the CLAUDE.md learning.
+
+### Phase 5: README & Slash Command Updates (`b4dfd7ae`, ~20 min)
+
+**What**: Updated README.md to document `/prompt` as a slash command alongside the natural language trigger. Updated the prompt skill description for consistency.
+
+**Decision**: Slash commands (`/prompt`) are the primary invocation method; natural language ("make a prompt") is secondary. README command table updated to reflect this.
+
+### Phase 6: Draft-PR Skill Discovery (`7f0e6fa9`, ~10 min)
+
+**What**: Tried to use `/draft-pr` to update PR #1's description. Discovered the skill existed on the `dx/draft-pr-skill` branch, not in the current branch.
+
+**Outcome**: Short session — confirmed the skill was on a separate branch and needed to be merged before it could be used from `feat/initial-setup`.
+
+### Phase 7: README Audit (`a9fed7dd`, ~30 min)
+
+**What**: Comprehensive audit of README against project conventions. Used a deep exploration agent to map every documented concept across CLAUDE.md, skills, meta entries, and infrastructure files.
+
+**Findings — 13 major documentation gaps**:
+
+| Gap | Impact |
+|-----|--------|
+| `/draft-pr` missing from commands table | Core command invisible |
+| Commit workflow with prompt files | Unique convention nobody would guess |
+| Git hooks behavior | Devs hit these immediately |
+| Prompt library system | Central to work tracking |
+| Developer journals structure | Per-author workflow |
+| Branch naming conventions | `feat/*`, `dx/*` patterns |
+| Per-developer config details | `project.local.yml` purpose unclear |
+| Nix/direnv rationale | Ceremony feels arbitrary without context |
+| App Group architecture | Critical for widget data sharing |
+| Architecture decisions | Why Swift over RN, why XcodeGen |
+| Skill discoverability | How to find and create skills |
+| Claude Code integration | What it means in practice |
+| Troubleshooting depth | Only brief section in README |
+
+**Response to Isaac's onboarding**: Several gaps directly map to friction Isaac documented — `direnv allow` timing ([001-environment-setup](../IsaacMenge/001-environment-setup.md) Phase 2), bundle ID ownership (Phase 6), and the setup skill not explaining what happens in each phase. The audit was partly motivated by making onboarding smoother.
+
+### Phase 8: PR Review Workflow Design (`b6c1c610`, ~1 hr)
+
+**What**: Designed an automated Claude-powered PR review system for GitHub Actions. Researched the `anthropics/claude-code-action` repository for reference architecture.
+
+**Research findings**:
+- `claude-code-action` uses an `.claude/agents/` directory with specialized reviewer agents (code-quality, security, documentation-accuracy, performance, test-coverage)
+- Each agent is a markdown file with focused review instructions
+- Agents are referenced from GitHub Actions workflows
+
+**Architecture decided**:
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Fix delivery | Push directly to PR branch | Simpler than follow-up PRs, clearer diff |
+| Fork PRs | Comment-only (no push) | GitHub security boundaries prevent branch push on forks |
+| Out-of-scope findings | Create GitHub issues | Don't block PR for unrelated problems |
+| Agent structure | Specialized reviewers | Mirrors anthropic's own pattern — focused scope per agent |
+
+**Connection to Isaac's experience**: Isaac's [001-environment-setup](../IsaacMenge/001-environment-setup.md) documented the Xcode 26 linker issue breaking `make build`. An automated CI/CD pipeline would catch these compatibility issues before they surprise new developers. The PR review system was partly motivated by having a second contributor whose environment differs from the original.
+
+## Response to Isaac's Journal Entries
+
+Isaac's [000-onboarding](../IsaacMenge/000-onboarding.md) made several observations worth responding to:
+
+**"The meta/prompt workflow is the interesting part, not the todo app itself"** — Exactly right. The app is a vehicle for the workflow system. The README audit (Phase 7) was partly about making this more visible — the README focused too much on the app and not enough on the collaboration system.
+
+**"Skills as human-readable, Claude-executable docs is a clean abstraction"** — This observation directly inspired the CLAUDE.md Philosophy section (Phase 4). The framing "written for humans, used by Claude" became the canonical way to describe skills.
+
+**"The PR description references steps but skips Step 5"** — Caught. The draft-PR skill exploration (Phase 6) was about improving these descriptions, but the skill wasn't yet available on the main branch.
+
+**"The relationship between meta entries and prompt files wasn't immediately clear"** — The README audit (Phase 7) flagged this exact gap. The prompt library system and its lifecycle (status: executed -> committed) wasn't documented in README at all.
+
+From Isaac's [001-environment-setup](../IsaacMenge/001-environment-setup.md):
+
+**Xcode 26 linker issue (`-Xlinker` incompatibility)** — This is a significant finding. `make build` is broken on Xcode 26 while Xcode GUI builds work fine. This affects CI/CD planning (Phase 8) — any GitHub Actions pipeline needs to either pin Xcode versions or use the `-ld_classic` flag.
+
+**Bundle ID ownership** — Free Apple accounts can't use another developer's bundle IDs. The `project.local.yml` pattern handles `DEVELOPMENT_TEAM` but not bundle IDs. Isaac's suggestion to support bundle ID overrides is worth implementing.
+
+**"direnv allow is needed before tools work, and a fresh terminal/Claude session is required after"** — This was flagged in the README audit as a gap. The setup skill documents it but README doesn't.
+
+## Developer Patterns Observed
+
+- **Documentation follows friction**: The README audit happened after Isaac's onboarding exposed real gaps. Documentation written before users arrive is always incomplete — the best time to fix docs is right after someone gets stuck.
+- **Skills beget skills**: Creating `/open-xcode` and `/prompt` in one session showed the skill-creator workflow is fast enough to capture utility skills opportunistically rather than waiting until they're "important enough."
+- **Audit before building**: The README audit (Phase 7) identified 13 gaps before writing a single line of documentation. Research-first pattern from 000 applied to docs.
+- **CI responds to team growth**: The PR review workflow (Phase 8) was motivated by having a second contributor. Solo developers don't need automated review; teams do.
+
+## Open Questions
+
+- How to fix `make build` for Xcode 26? (from Isaac's findings — `-ld_classic` flag, XcodeGen update, or accept GUI-only builds)
+- Should bundle ID overrides be supported in `project.local.yml`?
+- When to merge the README improvements identified in the audit?
+- Which specialized review agents to implement first? (code-quality and workflow-accuracy seem highest value)
+- Should the session-miner agent be improved to handle >1MB transcripts more reliably?
+
+## What's Next
+
+The documentation gaps are mapped. The CI/CD architecture is designed. Isaac is set up and contributing. The next phase should:
+1. Merge README improvements from the audit
+2. Implement the PR review GitHub Action with at least code-quality and workflow-accuracy agents
+3. Address the Xcode 26 build compatibility issue
+4. Start building actual app features — the DX foundation is mature enough

--- a/workflows/meta/gudnuf/004-ci-implementation-and-issue-triage.md
+++ b/workflows/meta/gudnuf/004-ci-implementation-and-issue-triage.md
@@ -1,0 +1,168 @@
+---
+id: "004"
+title: "CI/CD Implementation & Refinement"
+status: active
+author: gudnuf
+project: Slate
+tags: [ci, github-actions, testing, pr-review, issues, environment, app-group, permissions]
+previous: "003"
+sessions:
+  - id: 5ef2e65c
+    slug: app-group-build-setting
+    dir: Slate
+  - id: 284a51ea
+    slug: console-warnings-issue
+    dir: Slate
+  - id: 6052493e
+    slug: onboarding-friction-issue
+    dir: Slate
+  - id: 85aefd9b
+    slug: environment-enforcement
+    dir: Slate
+  - id: 7d842ab6
+    slug: pr-review-implementation
+    dir: Slate
+  - id: 7766f205
+    slug: github-actions-design
+    dir: Slate
+  - id: d5b3502f
+    slug: test-strategy-and-ci-gate
+    dir: Slate
+  - id: 8d7ae622
+    slug: unit-tests-and-ci-gate
+    dir: Slate
+  - id: 7d0d18d4
+    slug: issue-to-prompt-traceability
+    dir: Slate
+  - id: fbf115ed
+    slug: linux-ci-fix
+    dir: Slate
+  - id: da32fc0d
+    slug: claude-code-ci-integration
+    dir: Slate
+  - id: 443bdf5c
+    slug: ci-environment-config-fixes
+    dir: Slate
+  - id: eea792e9
+    slug: pr14-migration-instructions
+    dir: Slate
+prompts: []
+created: "2026-02-09T02:00:00Z"
+updated: "2026-02-09T02:45:00Z"
+---
+
+# 004: CI/CD Implementation & Refinement
+
+## Context
+
+Entry [003](003-docs-ci-and-onboarding.md) designed the CI/CD architecture and documented gaps. This entry covers the implementation burst that followed: building the test gate, automated PR review, environment enforcement, and issue triage — then refining it all until it actually worked cross-platform. All 13 sessions happened within a ~5 hour window on the same afternoon.
+
+## Timeline
+
+### App Group Build Setting Refactor (`5ef2e65c`)
+
+Replaced the hardcoded App Group identifier in `PersistenceConfig.swift` with a build-setting-driven value read from Info.plist via XcodeGen.
+
+**Key decision**: `fatalError` if the build setting is completely absent (catches developer misconfiguration) but graceful fallback if the App Group container is unavailable at runtime (handles unsigned/simulator builds). Missing config = developer error; missing entitlements = expected state.
+
+**Commit**: `9b19b06 refactor: replace hardcoded App Group ID with build setting variable`
+
+### Issue Triage from Onboarding (`284a51ea`, `6052493e`)
+
+Created two categorized GitHub issues from real developer friction:
+
+**[Issue #5](https://github.com/damsac/slate/issues/5) — Console warnings**: Diagnosed 6 Xcode warnings when adding todos. 3 actionable (App Group guard, toolbar Spacer, frame sizing), 3 system noise (Apple UIKit internals, simulator-only). Documented which to fix vs. ignore.
+
+**[Issue #6](https://github.com/damsac/slate/issues/6) — Onboarding friction**: Distilled 5 problems from Isaac's PR #4 journal entries: `make build` broken on Xcode 26 (new linker), no bundle ID overrides, direnv not active for Claude Code, no disk space check, Xcode version undocumented. Issues from real friction, not speculation.
+
+### Environment Enforcement (`85aefd9b`)
+
+Added a `shellHook` in `flake.nix` that checks `xcodebuild -version` on shell activation and warns if below Xcode 26.
+
+**Decision**: Warning, not error — allows flexibility while encouraging standardization. Catches issues before build attempts fail.
+
+**Commit**: `f8b6a06 feat: enforce development environment requirements (#14)`
+
+### PR Review System (`7d842ab6`)
+
+Implemented the automated PR review designed in 003:
+
+| File | Purpose |
+|------|---------|
+| `.claude/agents/code-reviewer.md` | Read-only agent: App Group safety, dead code, duplication |
+| `.claude/agents/workflow-reviewer.md` | Read-only agent: prompt/meta file integrity |
+| `.claude/commands/review-pr.md` | Orchestrator: dispatches agents, pushes fixes, posts comments |
+| `.github/workflows/claude-review.yml` | GitHub Actions trigger on PR open/push |
+
+**Architecture**: Dual-agent with write-only orchestrator. Agents observe via `Bash(git diff:*)` and `Bash(git log:*)`; only the orchestrator can edit/push/comment. Fork detection downgrades to comment-only mode.
+
+### Test Strategy, Implementation & CI Gate (`7766f205`, `d5b3502f`, `8d7ae622`)
+
+Designed and built the testing infrastructure across three sessions:
+
+**Test scope**: Pure-logic components only — `TodoItemTests`, `ThemeTests`, `PersistenceConfigTests` (~40 assertions). No SwiftData or UI tests.
+
+**Infrastructure**: XcodeGen test target in `project.yml`, `make test` in Makefile, `ci.yml` on `macos-latest`. Review job uses `needs: [test]` to gate behind passing tests.
+
+**Key decision — simplify CI**: Initial plan included Nix flake modifications and a parameterized `nix-ci` action. Dropped in favor of `brew install xcodegen xcbeautify` on the macOS runner — simpler, cheaper, faster.
+
+**Gotcha — exit code propagation**: `xcodebuild test | xcbeautify` always exits 0 even when tests fail (pipe hides exit code). Fixed with `set -o pipefail`.
+
+**Gotcha — pre-existing violations**: SwiftLint violations blocked the initial commit. Fixed all violations in a separate commit first (`c1ad78d`), then added test infrastructure.
+
+### Issue-to-Prompt Traceability (`7d0d18d4`)
+
+Added `issue: <number>` field to prompt file frontmatter so prompts and GitHub issues link bidirectionally.
+
+**Commit**: `9103971 feat: add issue field to prompt frontmatter for traceability` (PR #12)
+
+### Cross-Platform CI Fixes (`fbf115ed`, `da32fc0d`)
+
+**Linux fix**: Removed Nix setup action from `claude.yml` and `claude-review.yml` (leftover from the abandoned Nix CI approach). Made SwiftLint Darwin-conditional in `flake.nix` via `lib.optionals stdenv.isDarwin`. Tests are the quality gate; SwiftLint is a dev-time aid.
+
+**Claude Code integration fix**: Workflows had no system prompt (Claude ran with defaults, not project instructions), read-only permissions (couldn't commit or comment), and no agent access. Fixed by adding `--system-prompt-file` args, upgrading to write permissions, and adding tool allowlist.
+
+**Principle**: CI configuration should be explicit, not reliant on defaults. Defaults change; explicit configuration is reviewable and stable.
+
+### Entitlements Validation Fix (`443bdf5c`, `eea792e9`)
+
+The Makefile's post-generate validation still checked for the literal App Group string after Phase 1 switched to a build setting variable. Updated to check for `APP_GROUP_IDENTIFIER` variable presence instead of a specific value — validates structure, not content.
+
+Added migration instructions to PR #14 for developers with modified bundle IDs.
+
+**Commits**: `5babaed`, `88fc027` (PR #14)
+
+## PRs Merged
+
+| PR | What |
+|----|------|
+| #1 | Original app + DX infrastructure |
+| #3 | Nix CI environment for Claude Code |
+| #4 | Isaac's journal entries |
+| #7 | Automated PR review system |
+| #12 | Issue-to-prompt traceability |
+| #13 | Unit tests + CI test gate |
+| #14 | Variable-based entitlements validation |
+
+## Patterns
+
+- **Design then implement in one day**: 003 designed the CI architecture; this entry implemented it within hours. Design-first meant implementation was focused because decisions were already made.
+- **Issues from empathy, not abstraction**: Issues #5 and #6 came from reading another developer's actual experience, not from imagining what might go wrong.
+- **Simplify mid-flight**: Test strategy started as a 10-file Nix-heavy plan and ended as a 6-file brew-based approach. Recognizing when infrastructure complexity exceeds its value is as important as the initial design.
+- **Variable-based validation over literal checks**: When validating generated code, check for structure (variable presence) rather than content (specific value). Resilient to per-developer customization.
+- **Platform-aware CI**: Tools should only be required where they can run. Graceful degradation via `lib.optionals stdenv.isDarwin`.
+- **Migration docs for breaking changes**: When a PR changes developer workflow, document the migration path in the PR description.
+
+## Open Questions
+
+- Issue #5: When to fix the 3 actionable console warnings?
+- Issue #6: Bundle ID prefix override in `project.local.yml` — cleanest way across project.yml, Makefile, and PersistenceConfig?
+- Should SwiftLint return to CI as a parallel lint job, or stay dev-time only?
+- Issue-to-prompt linking is one-directional (prompt → issue). Should there be a reciprocal mechanism?
+
+## What's Next
+
+The CI pipeline is operational: tests gate PRs, Claude reviews automatically, environment enforcement is active. Remaining:
+1. Fix 3 actionable console warnings (issue #5)
+2. Implement bundle ID overrides (issue #6)
+3. Ship app features — infrastructure is mature enough for iterative development

--- a/workflows/meta/gudnuf/005-meta-workflow-infrastructure.md
+++ b/workflows/meta/gudnuf/005-meta-workflow-infrastructure.md
@@ -1,0 +1,103 @@
+---
+id: "005"
+title: "Meta-Workflow Infrastructure"
+status: active
+author: gudnuf
+project: Slate
+tags: [meta-workflow, documentation, session-miner, context-limits, haiku-model]
+previous: "004"
+sessions:
+  - id: 86e4208f
+    slug: session-miner-and-meta-tooling
+    dir: Slate
+  - id: d3c3dd71
+    slug: meta-workflow-context-limit-diagnosis
+    dir: Slate
+  - id: ad31e146
+    slug: meta-workflow-execution-entries-003-005
+    dir: Slate
+prompts: []
+created: "2026-02-09T00:27:22Z"
+updated: "2026-02-09T01:23:55Z"
+---
+
+# 005: Meta-Workflow Infrastructure
+
+## Context
+
+Entries 003-004 were written by the meta-workflow system itself, but the tooling that made that possible was built and debugged across these sessions. This entry covers the creation of the session-miner agent, the diagnosis of context limit failures when processing 42 sessions (30MB of JSONL), and the refactored architecture that made batch documentation viable.
+
+## Timeline
+
+### Session-Miner Agent Creation (`86e4208f`)
+
+Created `.claude/agents/session-miner.md` — a lightweight Haiku-model agent with only Read + Grep tools. Reads a single JSONL transcript and returns a structured summary: GOAL, OUTCOME, DECISIONS, PROBLEMS, FILES, COMMITS, THINKING.
+
+Uses chunked reading: first 100 lines, middle 100, last 100. This handles both 15KB and 3.7MB files without hitting context limits.
+
+Updated the meta-workflow SKILL.md to formalize the orchestration pattern: Python-based session discovery, batch size of 8, parallel mining with result aggregation.
+
+**Design principle**: Miners handle transcript parsing (cheap, parallel). The meta-workflow orchestrates discovery, git log fetching, dispatch, and synthesis (expensive, serial). Keeps the main agent context-light.
+
+### Context Limit Diagnosis (`d3c3dd71`, ~1.5 hrs)
+
+Investigated why `/meta-workflow` failed on the full session backlog.
+
+**Root cause**: The skill launched unlimited parallel subagents on all 42 session files (30MB total). Even with "keep under 600 words" instructions, the main agent still had to: discover all sessions (bloats context), launch 20+ subagents, collect all results back, then write the narrative.
+
+**Fixes designed**:
+
+| Problem | Fix |
+|---------|-----|
+| 42 sessions at once | Date-based filtering — only mine since last entry |
+| No batch limit | Cap at 8 sessions per entry |
+| Large files read whole | Chunked reading (first+middle+last 100 lines) |
+| Results bloat main context | Run miners in background, pull only summaries |
+| Sonnet model for extraction | Haiku model — 40-50% fewer tokens, sufficient quality |
+
+### Execution — Entries 003-005 (`ad31e146`, ~1.5 hrs)
+
+Applied the refactored workflow to mine 23 sessions and create three narrative entries.
+
+Launched 24 Haiku miners concurrently. Grouped results by functional scope (docs/onboarding, CI implementation, CI refinement) rather than chronological time. Synthesized miner outputs into timeline phases with decisions, patterns, and cross-references.
+
+**Problem**: First 4 miners failed due to wildcard paths not resolving. Fixed by providing exact file paths on retry. Demonstrates that miners need explicit paths, not glob patterns.
+
+**Outcome**: Three entries (~250-280 lines each) covering the full CI/CD implementation arc.
+
+## Architecture
+
+The meta-workflow operates as a three-phase system:
+
+```
+Phase 1: Discovery
+├─ Read existing entries' sessions: frontmatter → build covered set
+├─ Python script finds uncovered sessions by date + size
+└─ Group into batches of 8
+
+Phase 2: Mining
+├─ Fetch git log for time range (one command, pass slices to miners)
+├─ Launch parallel Haiku miners (run_in_background: true)
+└─ Each miner reads chunked JSONL, returns structured summary
+
+Phase 3: Synthesis
+├─ Collect miner results
+├─ Organize by functional scope into timeline phases
+└─ Write narrative with decisions, problems, patterns
+```
+
+## Learnings
+
+1. **Haiku is sufficient** for transcript summarization — don't default to Sonnet
+2. **8 sessions per entry** is practical — parallel mining showed good throughput without context bloat
+3. **Chunked reading should be default** — first+middle+last 100 lines works for files of any size
+4. **Explicit paths beat wildcards** — session miners need exact file paths
+5. **Always use Python for session discovery** — the Nix devShell provides GNU coreutils, so macOS `stat`/`date` flags silently produce wrong output
+6. **Background agents reduce context pressure** — main agent continues planning while miners work
+
+## What's Next
+
+The meta-workflow infrastructure is production-ready. Entries 003-004 prove it works at scale. Remaining:
+1. Formalize as a quarterly/weekly documentation cycle — date-filter to sessions since last entry, mine, publish
+2. Consider dynamic batch sizes based on file size rather than fixed 8
+3. Optional validation — miners could check that returned commits exist in git log


### PR DESCRIPTION
Used almost all my Claude usage creating these journal entries retroactively... this /meta-workflow is definitely expensive on the usage. I think this is cool and useful for following what each other are doing, but no pressure to do it extensively if its wasting all your usage when you could be writing code.

Optimized the meta-workflow skill to use haiku sub-agents for session mining so the main agent doesn't blow its context window on 30MB of transcripts.

**Tip:** When running `/meta-workflow`, use `/model` or `claude --model haiku` to set the orchestrating agent to haiku too — the journal entries don't need opus-level reasoning and it saves a ton of usage.

